### PR TITLE
Añadir a la nota rápida la URL cuando se copia texto de la web.

### DIFF
--- a/addon/globalPlugins/zUtilidades/__init__.py
+++ b/addon/globalPlugins/zUtilidades/__init__.py
@@ -26,6 +26,16 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import varGlobal
 from zLauncher import zl_modulo as zl
 from zNotes import zn_modulo as zn
+from comtypes.gen.ISimpleDOM import ISimpleDOMDocument
+import controlTypes
+# controlTypes module compatibility with old versions of NVDA
+if not hasattr(controlTypes, "Role"):
+	setattr(controlTypes, "Role", type('Enum', (), dict(
+	[(x.split("ROLE_")[1], getattr(controlTypes, x)) for x in dir(controlTypes) if x.startswith("ROLE_")])))
+	setattr(controlTypes, "State", type('Enum', (), dict(
+	[(x.split("STATE_")[1], getattr(controlTypes, x)) for x in dir(controlTypes) if x.startswith("STATE_")])))
+	setattr(controlTypes, "role", type("role", (), {"roleLabels": controlTypes.role._roleLabels}))
+# End of compatibility fixes
 
 # For translationn
 addonHandler.initTranslation()
@@ -209,6 +219,9 @@ No es posible tener dos instancias a la vez.""")
 						varGlobal.mensaje(_("Seleccione un texto para poder agregar a una nota rápida"))
 						return
 				# Fin código obtenido de Buscador de definiciones de la RAE (DLEChecker) de Antonio Cascales
+				if varGlobal.urlCaptura:
+					url = self.getURL()
+					selectedText = "\n\n".join([selectedText, url]) if url else selectedText
 				self.lanzador = "zn"
 				indiceNotes = varGlobal.dbDatos(os.path.join(zn.ajustes.dbDir, "index.dat")).CargaDatosIndex()
 				self.NewCategorias =  varGlobal.AnalizaDatos(indiceNotes).GetCategoria()
@@ -233,6 +246,23 @@ No es posible tener dos instancias a la vez.""")
 		else:
 			pass
 
+
+	def getURL(self):
+		""" Si se ha seleccionado texto de  una página web se obtiene la URL del documento para anexarla a la nota. """
+		try:
+			if api.getFocusObject().treeInterceptor.passThrough == False:
+				from comtypes.gen.ISimpleDOM import ISimpleDOMDocument
+				for obj in globalVars.focusAncestors:
+					try:
+						if obj.role == controlTypes.Role.DOCUMENT:
+							# Thanks to Alberto Buffolino, who discovered this method. https://nvda-addons.groups.io/g/nvda-addons/message/12943
+							doc = obj.IAccessibleObject.QueryInterface(ISimpleDOMDocument)
+							return doc.url
+					except:
+						pass
+			return None
+		except AttributeError:
+			return None
 
 	def newNote(self, event):
 		if self.doblePulsacion == True:

--- a/addon/globalPlugins/zUtilidades/__init__.py
+++ b/addon/globalPlugins/zUtilidades/__init__.py
@@ -248,7 +248,7 @@ No es posible tener dos instancias a la vez.""")
 
 
 	def getURL(self):
-		""" Si se ha seleccionado texto de  una página web se obtiene la URL del documento para anexarla a la nota. """
+		""" Se obtiene la URL del documento para anexarla a la nota. """
 		try:
 			if api.getFocusObject().treeInterceptor.passThrough == False:
 				from comtypes.gen.ISimpleDOM import ISimpleDOMDocument
@@ -260,6 +260,16 @@ No es posible tener dos instancias a la vez.""")
 							return doc.url
 					except:
 						pass
+			# Si el flujo llega hasta aquí es que no se ha encontrado el objeto documento. Lo buscamos de otra forma: desde el objeto enfocado hacia arriba en el árbol.
+			obj = api.getFocusObject()
+			while obj:
+				try:
+					if obj.role == controlTypes.Role.DOCUMENT:
+						doc = obj.IAccessibleObject.QueryInterface(ISimpleDOMDocument)
+						return doc.url
+				except:
+					pass
+				obj = obj.parent
 			return None
 		except AttributeError:
 			return None

--- a/addon/globalPlugins/zUtilidades/__init__.py
+++ b/addon/globalPlugins/zUtilidades/__init__.py
@@ -290,6 +290,8 @@ Agregue una categoría antes para poder crear una nota rápida.""")
 					self.doblePulsacion = False
 					return
 				self.windowsApp = AñadirNotaCopia(gui.mainFrame, self.NewCategorias, self.newArchivoCategorias, None, 1)
+				url = self.getURL()
+				if url: self.windowsApp.textoNota.SetValue(url)
 				gui.mainFrame.prePopup()
 				self.windowsApp.Show()
 				self.doblePulsacion = False

--- a/addon/globalPlugins/zUtilidades/varGlobal/__init__.py
+++ b/addon/globalPlugins/zUtilidades/varGlobal/__init__.py
@@ -234,6 +234,7 @@ def mensaje(msg):
 def initConfiguration():
 	confspec = {
 		"tituloCaptura": "boolean(default=False)",
+		"urlCaptura": "boolean(default=False)",
 	}
 	config.conf.spec['zUtilidades'] = confspec
 
@@ -256,3 +257,7 @@ try:
 	tituloCaptura = getConfig("tituloCaptura")
 except:
 	tituloCaptura = False
+try:
+	urlCaptura = getConfig("urlCaptura")
+except:
+	urlCaptura = False

--- a/addon/globalPlugins/zUtilidades/zNotes/zn_modulo.py
+++ b/addon/globalPlugins/zUtilidades/zNotes/zn_modulo.py
@@ -674,6 +674,8 @@ Esta acción no es reversible.
 			dlg.Destroy()
 			varGlobal.setConfig("tituloCaptura", dlg.chkSave)
 			varGlobal.tituloCaptura = dlg.chkSave
+			varGlobal.setConfig("urlCaptura", dlg.chkURL.GetValue())
+			varGlobal.urlCaptura = dlg.chkURL.GetValue()
 		else:
 			dlg.Destroy()
 
@@ -1477,6 +1479,9 @@ class OpcionesDialogo(wx.Dialog):
 		self.chkSave = varGlobal.tituloCaptura
 		self.chkTitulo = wx.CheckBox(self.panel_1, wx.ID_ANY, _("Capturar el título de la ventana en las notas rápidas (desde cualquier parte)"))
 		self.chkTitulo.SetValue(self.chkSave)
+
+		self.chkURL = wx.CheckBox(self.panel_1, wx.ID_ANY, _("Anexar la URL del documento a las notas rápidas  cuando se copia texto de una página web."))
+		self.chkURL.SetValue(varGlobal.urlCaptura)
 
 		self.aceptarBTN = wx.Button(self.panel_1, 1, _("&Aceptar"))
 		self.cancelarBTN = wx.Button(self.panel_1, 2, _("&Cancelar"))


### PR DESCRIPTION
He implementado la opción de anexar al final de la nota rápida la URL del documento cuando se copia texto desde una página web. En Firefox funciona, debería funcionar en todos los navegadores.

En el diálogo de opciones de notas rápidas he añadido una casilla para activar/desactivar esta función. Por defecto la he dejado desactivada.